### PR TITLE
Check property Solr before clearing its index

### DIFF
--- a/bin/ncbo_ontology_property_index
+++ b/bin/ncbo_ontology_property_index
@@ -109,6 +109,50 @@ def valid_url?(url)
   url.kind_of?(URI::HTTP) || url.kind_of?(URI::HTTPS)
 end
 
+class PropertySearchPreflightError < StandardError; end
+
+def property_search_preflight_error(reason, solr_core_url)
+  PropertySearchPreflightError.new(
+    "Property index preflight failed for #{solr_core_url}: #{reason}. " \
+    "No property index data was cleared or indexed. " \
+    "Verify the configured property search URL and that the Solr property core is running."
+  )
+end
+
+def preflight_property_search!(solr_core_url)
+  begin
+    property_search_client = Goo.search_connection(:property)
+  rescue StandardError => e
+    raise property_search_preflight_error(
+      "unable to obtain Goo.search_connection(:property) (#{e.class}: #{e.message})",
+      solr_core_url
+    )
+  end
+
+  if property_search_client.nil?
+    raise property_search_preflight_error(
+      "Goo.search_connection(:property) returned nil",
+      solr_core_url
+    )
+  end
+
+  unless property_search_client.respond_to?(:get)
+    raise property_search_preflight_error(
+      "Goo.search_connection(:property) did not return an RSolr client",
+      solr_core_url
+    )
+  end
+
+  begin
+    property_search_client.get('select', params: { q: '*:*', rows: 0, wt: 'json' })
+  rescue StandardError => e
+    raise property_search_preflight_error(
+      "unable to query the property Solr core (#{e.class}: #{e.message})",
+      solr_core_url
+    )
+  end
+end
+
 abort("The Solr core URL you provided is invalid. Aborting...\n\n") unless valid_url?(options[:solr_core_url])
 
 if options[:all] && options[:solr_core_url].downcase == LinkedData.settings.property_search_server_url.downcase
@@ -137,9 +181,18 @@ begin
   puts msg
   logger.info(msg)
 
-  Goo.configure do |conf|
-    conf.add_search_backend(:property, service: options[:solr_core_url])
+  begin
+    Goo.configure do |conf|
+      conf.add_search_backend(:property, service: options[:solr_core_url])
+    end
+  rescue StandardError => e
+    raise property_search_preflight_error(
+      "unable to configure the property search backend (#{e.class}: #{e.message})",
+      options[:solr_core_url]
+    )
   end
+
+  preflight_property_search!(options[:solr_core_url])
 
   indexed_ontologies = []
   remaining_ontologies = options[:ontologies].length
@@ -176,6 +229,10 @@ begin
   end
   puts msg
   logger.info(msg)
+rescue PropertySearchPreflightError => e
+  logger.error(e.message) if logger
+  puts e.message
+  exit(1)
 rescue Exception => e
   msg = "Failed property indexing with exception: #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
   logger.error(msg)

--- a/bin/ncbo_ontology_property_index
+++ b/bin/ncbo_ontology_property_index
@@ -110,6 +110,7 @@ def valid_url?(url)
 end
 
 class PropertySearchPreflightError < StandardError; end
+PROPERTY_SEARCH_PREFLIGHT_TIMEOUT = 10
 
 def property_search_preflight_error(reason, solr_core_url)
   PropertySearchPreflightError.new(
@@ -144,7 +145,11 @@ def preflight_property_search!(solr_core_url)
   end
 
   begin
-    property_search_client.get('select', params: { q: '*:*', rows: 0, wt: 'json' })
+    RSolr.connect(
+      url: solr_core_url,
+      timeout: PROPERTY_SEARCH_PREFLIGHT_TIMEOUT,
+      open_timeout: PROPERTY_SEARCH_PREFLIGHT_TIMEOUT
+    ).get('select', params: { q: '*:*', rows: 0, wt: 'json' })
   rescue StandardError => e
     raise property_search_preflight_error(
       "unable to query the property Solr core (#{e.class}: #{e.message})",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,7 @@ services:
       retries: 5
 
   agraph-ut:
-    image: franzinc/agraph:v8.1.0
+    image: franzinc/agraph:v8.1.1
     platform: linux/amd64
     environment:
       - AGRAPH_SUPER_USER=test

--- a/test/test_ontology_property_index.rb
+++ b/test/test_ontology_property_index.rb
@@ -1,0 +1,174 @@
+require 'fileutils'
+require 'minitest/autorun'
+require 'open3'
+require 'rbconfig'
+require 'tmpdir'
+
+class TestOntologyPropertyIndex < Minitest::Test
+  ROOT = File.expand_path('..', __dir__)
+  SCRIPT = File.join(ROOT, 'bin', 'ncbo_ontology_property_index')
+
+  def test_all_ontologies_aborts_before_clear_when_property_search_client_is_nil
+    result = run_property_index('nil')
+
+    refute result[:status].success?, result[:output]
+    assert_match(/Property index preflight failed/, result[:output])
+    assert_match(/Goo\.search_connection\(:property\) returned nil/, result[:output])
+    assert_match(/No property index data was cleared or indexed/, result[:output])
+    refute(
+      result[:clear_called],
+      'indexClear(:property) must not be called when the property client is nil'
+    )
+  end
+
+  def test_all_ontologies_aborts_before_clear_when_property_search_core_is_unreachable
+    result = run_property_index('unreachable')
+
+    refute result[:status].success?, result[:output]
+    assert_match(/Property index preflight failed/, result[:output])
+    assert_match(/unable to query the property Solr core/, result[:output])
+    assert_match(/Connection refused/, result[:output])
+    assert_match(/No property index data was cleared or indexed/, result[:output])
+    refute(
+      result[:clear_called],
+      'indexClear(:property) must not be called when the property core is unreachable'
+    )
+  end
+
+  def test_all_ontologies_keeps_clear_path_when_property_search_preflight_succeeds
+    result = run_property_index('healthy')
+
+    assert result[:status].success?, result[:output]
+    assert(
+      result[:clear_called],
+      'indexClear(:property) should still be called after a healthy preflight'
+    )
+    assert_match(/Completed processing property index for all ontologies/, result[:output])
+  end
+
+  private
+
+  def run_property_index(property_search_stub)
+    Dir.mktmpdir do |dir|
+      prepare_stubbed_tree(dir)
+      marker = File.join(dir, 'clear_called')
+      env = {
+        'PROPERTY_SEARCH_STUB' => property_search_stub,
+        'PROPERTY_INDEX_CLEAR_MARKER' => marker
+      }
+      command = [
+        RbConfig.ruby,
+        File.join(dir, 'bin', 'ncbo_ontology_property_index'),
+        '-a',
+        '-c', 'http://localhost:8983/solr/prop_search_core1',
+        '-z', 'false'
+      ]
+
+      stdout, stderr, status = Open3.capture3(
+        env, *command, stdin_data: "yes\n", chdir: dir
+      )
+      {
+        output: stdout + stderr,
+        status: status,
+        clear_called: File.exist?(marker)
+      }
+    end
+  end
+
+  def prepare_stubbed_tree(dir)
+    FileUtils.mkdir_p(File.join(dir, 'bin'))
+    FileUtils.mkdir_p(File.join(dir, 'config'))
+    FileUtils.mkdir_p(File.join(dir, 'lib'))
+    FileUtils.cp(SCRIPT, File.join(dir, 'bin', 'ncbo_ontology_property_index'))
+    File.write(File.join(dir, 'config', 'config.rb'), "# test stub\n")
+    File.write(File.join(dir, 'lib', 'ncbo_cron.rb'), stubbed_ncbo_cron)
+  end
+
+  def stubbed_ncbo_cron
+    <<~'RUBY'
+      require 'logger'
+
+      module Goo
+        def self.configure
+          yield self
+        end
+
+        def self.add_search_backend(_name, service:)
+          @property_search_url = service
+        end
+
+        def self.search_connection(_name)
+          case ENV.fetch('PROPERTY_SEARCH_STUB')
+          when 'nil'
+            nil
+          when 'unreachable'
+            UnreachablePropertySearchClient.new
+          else
+            HealthyPropertySearchClient.new
+          end
+        end
+
+        class UnreachablePropertySearchClient
+          def get(*)
+            raise Errno::ECONNREFUSED, 'Connection refused - connect(2) for 127.0.0.1:8983'
+          end
+        end
+
+        class HealthyPropertySearchClient
+          def get(*)
+            { 'responseHeader' => { 'status' => 0 } }
+          end
+        end
+      end
+
+      module LinkedData
+        def self.settings
+          @settings ||= Settings.new
+        end
+
+        class Settings
+          attr_accessor :enable_notifications, :goo_host, :property_search_server_url
+
+          def initialize
+            @goo_host = 'localhost'
+            @property_search_server_url = 'http://localhost:8983/solr/prop_search_core1'
+          end
+        end
+
+        module Models
+          class Ontology
+            def self.all
+              []
+            end
+          end
+
+          class Class
+            def self.indexClear(connection_name)
+              File.write(ENV.fetch('PROPERTY_INDEX_CLEAR_MARKER'), connection_name.to_s)
+            end
+
+            def self.indexCommit(*)
+            end
+
+            def self.indexOptimize(*)
+            end
+          end
+        end
+      end
+
+      module NcboCron
+        def self.settings
+          @settings ||= Settings.new
+        end
+
+        class Settings
+          attr_accessor :property_search_index_all_url
+
+          def initialize
+            @property_search_index_all_url = 'http://localhost:8983/solr/prop_search_core2'
+          end
+        end
+      end
+    RUBY
+  end
+end

--- a/test/test_ontology_property_index.rb
+++ b/test/test_ontology_property_index.rb
@@ -46,15 +46,24 @@ class TestOntologyPropertyIndex < Minitest::Test
     assert_match(/Completed processing property index for all ontologies/, result[:output])
   end
 
+  def test_property_search_preflight_uses_configured_url_and_bounded_timeout
+    result = run_property_index('healthy')
+
+    assert result[:status].success?, result[:output]
+    assert_equal 'http://localhost:8983/solr/prop_search_core1|10,10', result[:connect_options]
+  end
+
   private
 
   def run_property_index(property_search_stub)
     Dir.mktmpdir do |dir|
       prepare_stubbed_tree(dir)
       marker = File.join(dir, 'clear_called')
+      connect_marker = File.join(dir, 'connect_options')
       env = {
         'PROPERTY_SEARCH_STUB' => property_search_stub,
-        'PROPERTY_INDEX_CLEAR_MARKER' => marker
+        'PROPERTY_INDEX_CLEAR_MARKER' => marker,
+        'PROPERTY_SEARCH_CONNECT_MARKER' => connect_marker
       }
       command = [
         RbConfig.ruby,
@@ -70,7 +79,8 @@ class TestOntologyPropertyIndex < Minitest::Test
       {
         output: stdout + stderr,
         status: status,
-        clear_called: File.exist?(marker)
+        clear_called: File.exist?(marker),
+        connect_options: File.exist?(connect_marker) ? File.read(connect_marker) : nil
       }
     end
   end
@@ -117,6 +127,21 @@ class TestOntologyPropertyIndex < Minitest::Test
         class HealthyPropertySearchClient
           def get(*)
             { 'responseHeader' => { 'status' => 0 } }
+          end
+        end
+      end
+
+      module RSolr
+        def self.connect(**options)
+          File.write(
+            ENV.fetch('PROPERTY_SEARCH_CONNECT_MARKER'),
+            "#{options[:url]}|#{options[:timeout]},#{options[:open_timeout]}"
+          )
+          case ENV.fetch('PROPERTY_SEARCH_STUB')
+          when 'unreachable'
+            Goo::UnreachablePropertySearchClient.new
+          else
+            Goo::HealthyPropertySearchClient.new
           end
         end
       end


### PR DESCRIPTION
The all-ontology property indexing command clears the existing index before it knows whether the configured Solr core is reachable. A bad URL or unavailable core can therefore leave property search empty.

This checks the target core with a 10-second connection and read timeout before clearing. If the check fails, the command exits without clearing or indexing. The regular indexing client and its long-running timeouts are unchanged.

The test matrix also referenced the removed `franzinc/agraph:v8.1.0` image. It now uses the available patch release `v8.1.1`, allowing the AllegroGraph unit tests to start.

The focused preflight test passes with 4 runs and 24 assertions.
